### PR TITLE
Print available pools if list is called without indicating the target pool

### DIFF
--- a/dciqueue/list_cmd.py
+++ b/dciqueue/list_cmd.py
@@ -19,6 +19,7 @@
 import json
 import logging
 import os
+import sys
 
 from dciqueue import lib
 from dciqueue.run_cmd import EXT
@@ -32,11 +33,22 @@ def register_command(subparsers):
     parser = subparsers.add_parser(
         COMMAND, help="List the commands scheduled on a pool of resources"
     )
-    parser.add_argument("pool", help="Name of the pool")
+    parser.add_argument("pool", help="Name of the pool", nargs="?", default=None)
     return COMMAND
 
 
 def execute_command(args):
+    if args.pool == None:
+        print("The following pools were found:")
+        d = os.path.join(args.top_dir, "pool")
+        if os.path.exists(d):
+            p = os.listdir(d)
+            for pool in p:
+                print("  " + pool)
+        print("Run the command below for the list of commands scheduled on your target pool:")
+        print("  " + sys.argv[0] + " list <pool>")
+        return 0
+
     if not lib.check_pool(args):
         return 1
 


### PR DESCRIPTION
Just a user friendly feature.

When listing the scheduled commands, if no pool is indicated, the tool returns an error message so you have to go into /home/dciteam/.dci-queue/pool to get the list of configured pools.

Once you have the name of the pool you may run "list" not only to get the list of commands, but also information on the resources belonging to the pool.

This patch will get the list of available pools for the user and include instructions on how to use it instead of just printing the error message.